### PR TITLE
Update modsecurity.conf

### DIFF
--- a/src/main/infrastructure/nginx/config/modsecurity/modsecurity.conf
+++ b/src/main/infrastructure/nginx/config/modsecurity/modsecurity.conf
@@ -225,3 +225,6 @@ Include crs/*.conf
 # Customization.
 # Disables paranoia-2 DOS burst.
 SecRuleRemoveById 912171
+
+#For oauth
+SecRule ARGS:scope "@contains https://www.googleapis.com/auth/userinfo.profile" "id:'90000001',phase:2,t:none,t:lowercase,pass,nolog,ctl:ruleRemoveById=930120"


### PR DESCRIPTION
Acho que é uma boa criar essa regra pra liberar só para a google, hoje está liberado para todo mundo direto na diretiva do server.