### PR TITLE
Add remove temp service

### DIFF
--- a/src/main/infrastructure/nginx/script/nginx_remove_temporary_service_vhost.sh
+++ b/src/main/infrastructure/nginx/script/nginx_remove_temporary_service_vhost.sh
@@ -46,18 +46,8 @@ set -o nounset
 # Enables interruption signal handling.
 trap - INT TERM
 
-# Filter domains created by temporary services.
-TEMP_CERTS=$(grep -w "server_name" $VHOSTS_FOLDER/*http.conf | sed -e "s/.*server_name//g" | tr -d ';' | tr -d [:blank:] | grep "^${TEMP_PREFIX}-")
-
-${DEBUG} && echo "Running 'nginx_remove_branch_services_vhost'"
-
-# Removing services temporary certificates.
-for CERT in $TEMP_CERTS; do
-	${DEBUG} && echo "Removing certificates $CERT"
-	rm -rf /etc/letsencrypt/live/${CERT} -v 		|| true
-	rm -rf /etc/letsencrypt/renewal/${CERT}.conf -v || true
-	rm -rf /etc/letsencrypt/archive/${CERT} -v 		|| true
-done
+${DEBUG} && echo "Running 'nginx_remove_temporary_services_vhost'"
 
 # Removing temporary vhosts.
+${DEBUG} && echo "Removing temporary vhosts "
 rm $VHOSTS_FOLDER/${TEMP_PREFIX}-*.conf* -v || true

--- a/src/main/infrastructure/nginx/script/nginx_remove_temporary_service_vhost.sh
+++ b/src/main/infrastructure/nginx/script/nginx_remove_temporary_service_vhost.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+
+# Default script behavior.
+#set -o pipefail
+
+# Default parameters.
+DEBUG=${DEBUG:=true}
+DEBUG_OPT=
+VHOSTS_FOLDER=/etc/nginx/vhost.d
+BRANCH_PREFIX="feat"
+
+# For each argument.
+while :; do
+	case ${1} in
+		
+		# Debug argument.
+		--debug)
+			DEBUG=true
+			DEBUG_OPT="--debug"
+			;;
+			
+		# Other option.
+		?*)
+			printf 'WARN: Unknown option (ignored): %s\n' "$1" >&2
+			;;
+
+		# No more options.
+		*)
+			break
+
+	esac 
+	shift
+done
+
+# Using unavaialble variables should fail the script.
+set -o nounset
+
+# Enables interruption signal handling.
+trap - INT TERM
+
+# Filter domains created by temporary services.
+BRANCH_CERTS=$(grep -w "server_name" $VHOSTS_FOLDER/*http.conf | sed -e "s/.*server_name//g" | tr -d ';' | tr -d [:blank:] | grep "^${BRANCH_PREFIX}-")
+
+${DEBUG} && echo "Running 'nginx_remove_branch_services_vhost'"
+
+# Removing services branch certificates.
+for CERT in $BRANCH_CERTS; do
+	${DEBUG} && echo "Removing certificates $CERT"
+	certbot delete --cert-name $CERT --non-interactive || true
+	sleep 1
+done
+
+# Removing  temporary vhosts.
+rm $VHOSTS_FOLDER/${BRANCH_PREFIX}-*.conf* -v || true

--- a/src/main/infrastructure/nginx/script/nginx_remove_temporary_service_vhost.sh
+++ b/src/main/infrastructure/nginx/script/nginx_remove_temporary_service_vhost.sh
@@ -46,8 +46,6 @@ set -o nounset
 # Enables interruption signal handling.
 trap - INT TERM
 
-${DEBUG} && echo "Running 'nginx_remove_temporary_services_vhost'"
-
 # Removing temporary vhosts.
 ${DEBUG} && echo "Removing temporary vhosts "
 rm $VHOSTS_FOLDER/${TEMP_PREFIX}-*.conf* -v || true

--- a/src/main/infrastructure/nginx/script/nginx_remove_temporary_service_vhost.sh
+++ b/src/main/infrastructure/nginx/script/nginx_remove_temporary_service_vhost.sh
@@ -51,12 +51,13 @@ TEMP_CERTS=$(grep -w "server_name" $VHOSTS_FOLDER/*http.conf | sed -e "s/.*serve
 
 ${DEBUG} && echo "Running 'nginx_remove_branch_services_vhost'"
 
-# Removing services branch certificates.
+# Removing services temporary certificates.
 for CERT in $TEMP_CERTS; do
 	${DEBUG} && echo "Removing certificates $CERT"
-	certbot delete --cert-name $CERT --non-interactive || true
-	sleep 1
+	rm -rf /etc/letsencrypt/live/${CERT} -v 		|| true
+	rm -rf /etc/letsencrypt/renewal/${CERT}.conf -v || true
+	rm -rf /etc/letsencrypt/archive/${CERT} -v 		|| true
 done
 
-# Removing  temporary vhosts.
+# Removing temporary vhosts.
 rm $VHOSTS_FOLDER/${TEMP_PREFIX}-*.conf* -v || true


### PR DESCRIPTION
Esse cara é para limpar os certificado e vhosts que serão gerados por serviços que podem ter mais de 1 rodando ao mesmo tempo. 
Nesse caso não tem cron nem nada do tipo por que quem executa ele é o jenkins que primeiro deleta o serviço do mesos e em seguida deleta no proxy.