### PR TITLE
Remove missing ip from allowed ips

### DIFF
--- a/src/main/infrastructure/nginx/script/nginx_update_intranet.sh
+++ b/src/main/infrastructure/nginx/script/nginx_update_intranet.sh
@@ -64,6 +64,19 @@ do
 	
 		# If the Intranet IP is valid.
 		NET_IP=$( dig +short site${HOST_NUMBER}.${NET}.${HOST_NAME} | tail -1 )
+		
+		# Check if previous IP should be deleted from file.
+		UPDATE_LOOPBACK=false
+		INITIAL_OLD_IP=$(echo $OLD_HOST_CONFIG | cut -d " " -f2 | cut -c 1-3)
+		if [ -z "$NET_IP" ] && [ "$INITIAL_OLD_IP" != "127" ]; then
+			# Use loopback value to update previous value if none is found on route
+			NET_IP="127.0.0.1"
+			UPDATE_LOOPBACK=true
+			${DEBUG} && echo "INITIAL_OLD_IP=${INITIAL_OLD_IP}"
+			${DEBUG} && echo "NET_IP=${NET_IP}"
+			${DEBUG} && echo "UPDATE_LOOPBACK=${UPDATE_LOOPBACK}"
+		fi
+
 		if expr "${NET_IP}" : '^[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*$' >/dev/null; then
 		
 			# Gets the new host configuration.		
@@ -73,7 +86,8 @@ do
 			
 			# If the old configuration is present and the new configuration is not present.
 			if (cat ${CONF_FILE} | grep "${OLD_HOST_CONFIG}" >/dev/null) && \
-				! (cat ${CONF_FILE} | grep "${NEW_HOST_CONFIG}" >/dev/null)
+				! (cat ${CONF_FILE} | grep "${NEW_HOST_CONFIG}" >/dev/null) || \
+				${UPDATE_LOOPBACK}
 			then
 			
 				# Replaces them in the net file.
@@ -88,7 +102,6 @@ do
 				
 			# If the old configuration is not present.
 			else 
-				
 				# No old config is present.
 				${DEBUG} && echo "No old config present or new config already present."
 				


### PR DESCRIPTION
Hoje não é retirado o ip automaticamente ao remover o IP da intranet, a ideia é que ao retirar remover também do access-intranet e não manter um ip permitido.
