### PR TITLE
Exclude unecessary folders

### DIFF
--- a/src/main/infrastructure/nginx/script/nginx_sync_config.sh
+++ b/src/main/infrastructure/nginx/script/nginx_sync_config.sh
@@ -70,7 +70,7 @@ then
 		${DEBUG} && echo "Failed to download folder"
 		exit 0
 	fi
-	wget --recursive --no-parent -q -R "index.html*" -P ${CERTS_TMP}/../.. ${CONF_HOST_NAME}/cert/ --exclude-directories=/cert/archive,/cert/csr,/cert/keys
+	wget --recursive --no-parent -q -R "index.html*" -P ${CERTS_TMP}/../.. ${CONF_HOST_NAME}/cert/ --exclude-directories="cert/archive,cert/csr,cert/keys"
 	wget --recursive --no-parent -q -R "index.html*" -P ${STREAM_TMP}/../.. ${CONF_HOST_NAME}/stream/
 
 	if ! diff -rq ${CERTS} ${CERTS_TMP}

--- a/src/main/infrastructure/nginx/script/nginx_sync_config.sh
+++ b/src/main/infrastructure/nginx/script/nginx_sync_config.sh
@@ -70,7 +70,7 @@ then
 		${DEBUG} && echo "Failed to download folder"
 		exit 0
 	fi
-	wget --recursive --no-parent -q -R "index.html*" -P ${CERTS_TMP}/../.. ${CONF_HOST_NAME}/cert/
+	wget --recursive --no-parent -q -R "index.html*" -P ${CERTS_TMP}/../.. ${CONF_HOST_NAME}/cert/ --exclude-directories=/cert/archive,/cert/csr,/cert/keys
 	wget --recursive --no-parent -q -R "index.html*" -P ${STREAM_TMP}/../.. ${CONF_HOST_NAME}/stream/
 
 	if ! diff -rq ${CERTS} ${CERTS_TMP}


### PR DESCRIPTION
No distributor de entrada não precisamos baixar esses arquivos, acaba tendo um tempo de download excessivo que não é usado para nada nele.