### PR TITLE
improving logs

### DIFF
--- a/src/main/infrastructure/nginx/config/nginx/conf.d/http.d/logging.conf
+++ b/src/main/infrastructure/nginx/config/nginx/conf.d/http.d/logging.conf
@@ -3,7 +3,7 @@
 #access_log				${ACCESSLOG}		main				buffer=${LOG_BUFFER_MB}m		flush=${LOG_FLUSH_MILLIS}ms;
 				
 # Metrics.
-log_format timed_combined '[$time_local] $request_time $scheme $remote_user $host $remote_addr $server_name:$server_port "$request" $request_completion $status "$http_referer" "$http_user_agent" $request_length $bytes_sent $network';
+log_format timed_combined '[$time_local] $request_time $scheme $remote_user $host $remote_addr $server_name:$server_port "$request" $request_completion $status "$http_referer" "$http_user_agent" $request_length $bytes_sent $network $upstream_addr';
 access_log				${METRICSLOG}		timed_combined		buffer=${LOG_BUFFER_MB}m		flush=${LOG_FLUSH_MILLIS}ms;
 
 # Errors.

--- a/src/main/infrastructure/nginx/config/nginx/nginx.conf
+++ b/src/main/infrastructure/nginx/config/nginx/nginx.conf
@@ -63,6 +63,7 @@ http {
 
 	# Monitoring.
 	vhost_traffic_status_zone;
+	vhost_traffic_status_zone shared:vhost_traffic_status:8m;
 	
 	# Performance tools.
 	tcp_nodelay						on;


### PR DESCRIPTION
Adicionando o upstream ao log, para casos onde compartilham o vhost é importante para debugar.

Aumentando a memória para o modulo de monitoria para corrigir mensagens de erro

```
2025/10/31 11:10:17 [crit] 1445341#1445341: ngx_slab_alloc() failed: no memory in vhost_traffic_status_zone "ngx_http_vhost_traffic_status"
2025/10/31 11:10:17 [error] 1445338#1445338: *8163783 shm_add_node::ngx_slab_alloc_locked() failed: used_size[893577], used_node[251] while logging request, client: ...
```