### PR TITLE
- fix multiple roles per route;

### DIFF
--- a/src/main/infrastructure/nginx/script/nginx_create_access_control_config.sh
+++ b/src/main/infrastructure/nginx/script/nginx_create_access_control_config.sh
@@ -75,12 +75,13 @@ location /oauth2/ {
 EOF
 		printf '%s\n' "$AUTH_POLICIES" | tr ';' '\n' |
 		while IFS=':' read -r route roles; do
+			formatted_roles=$(printf '%s' "$roles" | sed 's/^/role:/;s/,/,role:/g')
 			cat <<EOF
 location = /oauth2/auth_$route {
     internal;
     auth_request off;
 
-    proxy_pass http://$ACCESS_SERVICE/oauth2/auth?allowed_groups=role:$roles;
+    proxy_pass http://$ACCESS_SERVICE/oauth2/auth?allowed_groups=$formatted_roles;
 
     proxy_hide_header Host;
     proxy_set_header Host \$server_name;


### PR DESCRIPTION
Multiplas roles eram declaradas separadas por vírgula depois do primeiro e único "role:", mas era necessário que cada role tivesse o prefixo "role:" e então separadas por vírgula.

role:r1,r2,r3  ->  role:r1,role:r2,role:r3                           